### PR TITLE
wifi: mt76: mt7915: disable VHT CAP SUPP CHAN WIDTH 160Mhz for mt7915

### DIFF
--- a/mt7915/init.c
+++ b/mt7915/init.c
@@ -413,11 +413,12 @@ mt7915_init_wiphy(struct mt7915_phy *phy)
 				IEEE80211_VHT_CAP_MAX_MPDU_LENGTH_7991 |
 				IEEE80211_VHT_CAP_MAX_A_MPDU_LENGTH_EXPONENT_MASK;
 
-			if (!dev->dbdc_support)
+			/*if (!dev->dbdc_support)
 				vht_cap->cap |=
 					IEEE80211_VHT_CAP_SHORT_GI_160 |
 					IEEE80211_VHT_CAP_SUPP_CHAN_WIDTH_160MHZ |
 					FIELD_PREP(IEEE80211_VHT_CAP_EXT_NSS_BW_MASK, 1);
+			*/
 		} else {
 			vht_cap->cap |=
 				IEEE80211_VHT_CAP_MAX_MPDU_LENGTH_11454 |

--- a/mt7915/init.c
+++ b/mt7915/init.c
@@ -415,6 +415,7 @@ mt7915_init_wiphy(struct mt7915_phy *phy)
 
 			if (!dev->dbdc_support)
 				vht_cap->cap |=
+					IEEE80211_VHT_CAP_SHORT_GI_160 |
 					FIELD_PREP(IEEE80211_VHT_CAP_EXT_NSS_BW_MASK, 1);
 			
 		} else {

--- a/mt7915/init.c
+++ b/mt7915/init.c
@@ -415,7 +415,6 @@ mt7915_init_wiphy(struct mt7915_phy *phy)
 
 			if (!dev->dbdc_support)
 				vht_cap->cap |=
-					IEEE80211_VHT_CAP_SUPP_CHAN_WIDTH_160MHZ |
 					FIELD_PREP(IEEE80211_VHT_CAP_EXT_NSS_BW_MASK, 1);
 			
 		} else {

--- a/mt7915/init.c
+++ b/mt7915/init.c
@@ -417,7 +417,6 @@ mt7915_init_wiphy(struct mt7915_phy *phy)
 				vht_cap->cap |=
 					IEEE80211_VHT_CAP_SHORT_GI_160 |
 					FIELD_PREP(IEEE80211_VHT_CAP_EXT_NSS_BW_MASK, 1);
-			
 		} else {
 			vht_cap->cap |=
 				IEEE80211_VHT_CAP_MAX_MPDU_LENGTH_11454 |

--- a/mt7915/init.c
+++ b/mt7915/init.c
@@ -413,12 +413,11 @@ mt7915_init_wiphy(struct mt7915_phy *phy)
 				IEEE80211_VHT_CAP_MAX_MPDU_LENGTH_7991 |
 				IEEE80211_VHT_CAP_MAX_A_MPDU_LENGTH_EXPONENT_MASK;
 
-			/*if (!dev->dbdc_support)
+			if (!dev->dbdc_support)
 				vht_cap->cap |=
-					IEEE80211_VHT_CAP_SHORT_GI_160 |
 					IEEE80211_VHT_CAP_SUPP_CHAN_WIDTH_160MHZ |
 					FIELD_PREP(IEEE80211_VHT_CAP_EXT_NSS_BW_MASK, 1);
-			*/
+			
 		} else {
 			vht_cap->cap |=
 				IEEE80211_VHT_CAP_MAX_MPDU_LENGTH_11454 |


### PR DESCRIPTION
Fixes buggy 802.11ax on the RT3200 when connecting to some clients.

Partially reverts https://patchwork.kernel.org/project/linux-wireless/patch/20230301163739.52314-1-nbd@nbd.name/

Forum thread https://forum.openwrt.org/t/802-11ax-worse-than-802-11ac-with-mt76-driver